### PR TITLE
Delete Suivant.ejs

### DIFF
--- a/macros/Suivant.ejs
+++ b/macros/Suivant.ejs
@@ -1,5 +1,0 @@
-<%
-/* one parameter: path of Next page */
-/* please use Next instead of this template */
-%>
-<%- template("Next", [$0]) %>


### PR DESCRIPTION
This macro was a translation of Next.ejs. It was only used by fr pages where I changed those to Next calls.
I've browsed the codebase and it doesn't seem to appear. (at least not by the simple name "Suivant").
I think we can safely get rid of this one.